### PR TITLE
Add windowed method for ec point scalar multiplication

### DIFF
--- a/src/gpu/entries/bls12-377Algorithms/aleoIsOwnerEntry.ts
+++ b/src/gpu/entries/bls12-377Algorithms/aleoIsOwnerEntry.ts
@@ -45,7 +45,7 @@ export const is_owner = async (
       var z = U256_ONE;
       var ext_p1 = Point(p1.x, p1.y, p1_t, z);
 
-      var multiplied = mul_point(ext_p1, EMBEDDED_SCALAR);
+      var multiplied = mul_point_windowed(ext_p1, EMBEDDED_SCALAR);
       var z_inverse = field_inverse(multiplied.z);
       var result = field_multiply(multiplied.x, z_inverse);
 

--- a/src/gpu/entries/curve/curveMulPointWindowed.test.ts
+++ b/src/gpu/entries/curve/curveMulPointWindowed.test.ts
@@ -1,0 +1,60 @@
+import puppeteer from 'puppeteer';
+import { Browser } from 'puppeteer';
+import { bigIntToU32Array, bigIntsToU32Array, u32ArrayToBigInts } from '../../utils';
+
+describe('curveMulPointWindowed', () => {
+  let browser: Browser;
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      executablePath: '/Applications/Google\ Chrome\ Beta.app/Contents/MacOS/Google\ Chrome\ Beta',
+      devtools: true,
+      headless: false,
+      args: ['#enable-webgpu-developer-features']
+    });
+
+    const page = (await browser.pages())[0];
+    await page.goto("http://localhost:4000");
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  it.each([
+    [
+      BigInt('2796670805570508460920584878396618987767121022598342527208237783066948667246'),
+      BigInt('8134280397689638111748378379571739274369602049665521098046934931245960532166'),
+      BigInt('1753533570350686550323082834194063544688355123444645930667634514069517491627'),
+      BigInt('5324992470787461040823919570440348586607207885188029730405305593254964962313')
+    ],
+    [
+      BigInt('2796670805570508460920584878396618987767121022598342527208237783066948667246'),
+      BigInt('8134280397689638111748378379571739274369602049665521098046934931245960532166'),
+      BigInt('1'),
+      BigInt('2796670805570508460920584878396618987767121022598342527208237783066948667246')
+    ],
+    [
+      BigInt('2796670805570508460920584878396618987767121022598342527208237783066948667246'),
+      BigInt('8134280397689638111748378379571739274369602049665521098046934931245960532166'),
+      BigInt('2'),
+      BigInt('7304662912603109101654342147238231070235863099037011884568440290807776100174')
+    ]
+  ])('should multiply affine point by scalar', async (
+    p1x: bigint,
+    p1y: bigint,
+    scalar: bigint,
+    resultx: bigint,
+    // resulty: bigint
+    ) => {
+    // need to pass an untyped array here
+    const u32Input1 = Array.from(bigIntsToU32Array([p1x, p1y]));
+    const u32Input2 = Array.from(bigIntToU32Array(scalar));
+    const result = await ((await browser.pages())[0]).evaluate(`(point_mul_windowed)([${u32Input1}], [${u32Input2}])`);
+    const arr = Object.values(result as object);
+    const uint32ArrayResult = new Uint32Array(arr);
+    const bigIntsResult = u32ArrayToBigInts(uint32ArrayResult);
+
+    expect(bigIntsResult[0].toString()).toEqual(resultx.toString());
+    // expect(bigIntsResult[1].toString()).toEqual(resulty.toString());
+  });
+});

--- a/src/gpu/entries/curve/curveMulPointWindowedEntry.ts
+++ b/src/gpu/entries/curve/curveMulPointWindowedEntry.ts
@@ -1,0 +1,43 @@
+import { AFFINE_POINT_SIZE, FIELD_SIZE } from "../../U32Sizes";
+import { BLS12_377ParamsWGSL } from "../../wgsl/BLS12-377Params";
+import { CurveWGSL } from "../../wgsl/Curve";
+import { FieldModulusWGSL } from "../../wgsl/FieldModulus";
+import { U256WGSL } from "../../wgsl/U256";
+import { entry } from "../entryCreator"
+
+export const point_mul_windowed = async (input1: Array<number>, input2: Array<number>) => {
+  const shaderEntry = `
+    @group(0) @binding(0)
+    var<storage, read> input1: array<AffinePoint>;
+    @group(0) @binding(1)
+    var<storage, read> input2: Fields;
+    @group(0) @binding(2)
+    var<storage, read_write> output: Fields;
+
+    @compute @workgroup_size(64)
+    fn main(
+      @builtin(global_invocation_id)
+      global_id : vec3<u32>
+    ) {
+      var p1 = input1[global_id.x];
+      var p1_t = field_multiply(p1.x, p1.y);
+      var z = U256_ONE;
+      var ext_p1 = Point(p1.x, p1.y, p1_t, z);
+
+      var scalar = input2.fields[global_id.x];
+
+      var multiplied = mul_point_windowed(ext_p1, scalar);
+      var z_inverse = field_inverse(multiplied.z);
+      var result = field_multiply(multiplied.x, z_inverse);
+
+      output.fields[global_id.x] = result;
+    }
+    `;
+
+  const shaderModules = [U256WGSL, BLS12_377ParamsWGSL, FieldModulusWGSL, CurveWGSL, shaderEntry];
+
+  return await entry([input1, input2], shaderModules, AFFINE_POINT_SIZE, FIELD_SIZE);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).point_mul_windowed = point_mul_windowed;

--- a/src/ui/AllBenchmarks.tsx
+++ b/src/ui/AllBenchmarks.tsx
@@ -24,6 +24,7 @@ import { convertBytesToFieldElement, convertCiphertextToDataView, getNonce, getP
 import { aleo_poseidon_multi_2 } from '../gpu/entries/bls12-377Algorithms/aleoPoseidonMultiPass';
 import { naive_msm } from '../gpu/entries/naiveMSMEntry';
 import { point_add } from '../gpu/entries/curve/curveAddPointsEntry';
+import { point_mul_windowed } from '../gpu/entries/curve/curveMulPointWindowedEntry';
 
 const singleInputGenerator = (inputSize: number): bigint[][] => {
   return [generateRandomFields(inputSize)];
@@ -307,6 +308,15 @@ export const AllBenchmarks: React.FC = () => {
         name={'Point Scalar Mul'}
         inputsGenerator={pointScalarGenerator}
         gpuFunc={(inputs: number[][]) => point_mul(inputs[0], inputs[1])}
+        gpuInputConverter={gpuPointScalarInputConverter}
+        wasmFunc={(inputs: string[][]) => bulkGroupScalarMul(inputs[0], inputs[1])}
+        wasmInputConverter={wasmPointMulConverter}
+        wasmResultConverter={(results: string[]) => { return results.map((result) => stripGroupSuffix(result))}}
+      />
+      <Benchmark
+        name={'Point Scalar Mul Windowed'}
+        inputsGenerator={pointScalarGenerator}
+        gpuFunc={(inputs: number[][]) => point_mul_windowed(inputs[0], inputs[1])}
         gpuInputConverter={gpuPointScalarInputConverter}
         wasmFunc={(inputs: string[][]) => bulkGroupScalarMul(inputs[0], inputs[1])}
         wasmInputConverter={wasmPointMulConverter}


### PR DESCRIPTION
Sliding should be a few % faster but I couldn't get the correctness there. Current speed up for windowing is ~12%

I tried different window sizes and w = 4 seemed the fastest.

I didn't notice any new memory issues. Both the mul_point and mul_point_windowed stop working around ~15K input size on my computer.

<img width="1096" alt="Screenshot 2023-08-22 at 9 01 43 PM" src="https://github.com/demox-labs/webgpu-crypto/assets/1102811/c5b1a001-2d11-480e-bacf-8d68ba5f5b56">
